### PR TITLE
refactored app.py for app createion and made app_runner.py to run the…

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,25 +1,30 @@
+import config
+from config import config
 from flask import Flask
 from flask_restful import Api
 from flask_cors import CORS #comment this on deployment
 from api.InventoryTableApiHandler import InventoryTableApiHandler
 from api.StockTonerApiHandler import StockTonerApiHandler
 from api.TonerTypesApiHandler import TonerTypesApiHandler
-
 from authentication.auth import auth_app
 
-stc_app = Flask("STC Kilroy App")
-CORS(stc_app) #comment this on deployment
-api = Api(stc_app)
+
+def create_app(config_name):
+    stc_app = Flask(__name__)
+    stc_app.config.from_object(config[config_name])
+    config[config_name].init_app(stc_app)
+
+    CORS(stc_app)  # comment this on deployment
+    api = Api(stc_app)
+
+    # Register Flask-RESTful resources
+    api.add_resource(InventoryTableApiHandler, '/')
+    api.add_resource(StockTonerApiHandler, '/update_stock')
+    api.add_resource(TonerTypesApiHandler, '/get_toner_types')
+
+    # Register Blueprints
+    stc_app.register_blueprint(auth_app)
 
 
-# Register Flask-RESTful resources
-api.add_resource(InventoryTableApiHandler, '/')
-api.add_resource(StockTonerApiHandler, '/update_stock')
-api.add_resource(TonerTypesApiHandler, '/get_toner_types')
 
-
-# Register Blueprints
-stc_app.register_blueprint(auth_app)
-
-if __name__ == '__main__':
-    stc_app.run(debug=True, port=4444)
+    return stc_app

--- a/backend/app_runner.py
+++ b/backend/app_runner.py
@@ -1,0 +1,8 @@
+import os
+from app import create_app
+
+app = create_app(os.getenv('FLASK_CONFIG') or 'default')
+
+
+if __name__ == '__main__':
+    app.run(port=4444, debug=True)


### PR DESCRIPTION
… app. 

Made app.py responsible for app creation and registering off blueprints and app runner for running the app. This is important especially in the context of having 3 different configurations, production, testing, deployment, the runner script is able to connect to different databases dynamically when different configuration settings are applied, the default setting is production. I am going to make a small sqlite db for testing that way when I perform tests I don't interfere with the production database wrongly. 